### PR TITLE
Prevent null-reference errors on SetWindowDirection

### DIFF
--- a/1.0/WPFNotification/WPFNotification/Core/NotifyBox.cs
+++ b/1.0/WPFNotification/WPFNotification/Core/NotifyBox.cs
@@ -225,32 +225,39 @@ namespace WPFNotification.Core
         /// <param name="notificationFlowDirection"> Direction in which new notifications will appear.</param>
         private static void SetWindowDirection(Window window, NotificationFlowDirection notificationFlowDirection)
         {
-            var workingArea = System.Windows.Forms.Screen.PrimaryScreen.WorkingArea;
-            var transform = PresentationSource.FromVisual(Application.Current.MainWindow).CompositionTarget.TransformFromDevice;
-            var corner = transform.Transform(new Point(workingArea.Right, workingArea.Bottom));
-
-            switch (notificationFlowDirection)
+            try
             {
-                case NotificationFlowDirection.RightBottom:
-                    window.Left = corner.X - window.Width - window.Margin.Right - Margin;
-                    window.Top = corner.Y - window.Height - window.Margin.Top;
-                    break;
-                case NotificationFlowDirection.LeftBottom:
-                    window.Left = 0;
-                    window.Top = corner.Y - window.Height - window.Margin.Top;
-                    break;
-                case NotificationFlowDirection.LeftUp:
-                    window.Left = 0;
-                    window.Top = 0;
-                    break;
-                case NotificationFlowDirection.RightUp:
-                    window.Left = corner.X - window.Width - window.Margin.Right - Margin;
-                    window.Top = 0;
-                    break;
-                default:
-                    window.Left = corner.X - window.Width - window.Margin.Right - Margin;
-                    window.Top = corner.Y - window.Height - window.Margin.Top;
-                    break;
+                var workingArea = System.Windows.Forms.Screen.PrimaryScreen.WorkingArea;
+                var transform = PresentationSource.FromVisual(Application.Current.MainWindow).CompositionTarget.TransformFromDevice;
+                var corner = transform.Transform(new Point(workingArea.Right, workingArea.Bottom));
+
+                switch (notificationFlowDirection)
+                {
+                    case NotificationFlowDirection.RightBottom:
+                        window.Left = corner.X - window.Width - window.Margin.Right - Margin;
+                        window.Top = corner.Y - window.Height - window.Margin.Top;
+                        break;
+                    case NotificationFlowDirection.LeftBottom:
+                        window.Left = 0;
+                        window.Top = corner.Y - window.Height - window.Margin.Top;
+                        break;
+                    case NotificationFlowDirection.LeftUp:
+                        window.Left = 0;
+                        window.Top = 0;
+                        break;
+                    case NotificationFlowDirection.RightUp:
+                        window.Left = corner.X - window.Width - window.Margin.Right - Margin;
+                        window.Top = 0;
+                        break;
+                    default:
+                        window.Left = corner.X - window.Width - window.Margin.Right - Margin;
+                        window.Top = corner.Y - window.Height - window.Margin.Top;
+                        break;
+                }
+            }
+            catch
+            {
+                // Don't modify the window settings. If null-reference occurs, this allows the notification display to continue.
             }
         }
 


### PR DESCRIPTION
I noticed that it's possible for a null-reference error to occur when the notification calls SetWindowDirection. This stops the main application from running if WPFNotification hits this error.

I've fixed it by adding a try-catch to the method. It'll leave the window in it's default position. 

It's also made it work in the project I am currently using it in.