### PR TITLE
Removed dependency on System.Reactive.* dlls [Fixes Issue #2]

### DIFF
--- a/1.0/WPFNotification/WPFNotification/WPFNotification.csproj
+++ b/1.0/WPFNotification/WPFNotification/WPFNotification.csproj
@@ -45,21 +45,6 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Reactive.Core">
-      <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Reactive.Interfaces">
-      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Reactive.Linq">
-      <HintPath>..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Reactive.PlatformServices">
-      <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Reactive.Windows.Threading">
-      <HintPath>..\packages\Rx-XAML.2.2.5\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
-    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Expression.Blend.Sdk.1.0.2\lib\net45\System.Windows.Interactivity.dll</HintPath>

--- a/1.0/WPFNotification/WPFNotification/packages.config
+++ b/1.0/WPFNotification/WPFNotification/packages.config
@@ -1,11 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Expression.Blend.Sdk" version="1.0.2" targetFramework="net452" />
-  <package id="Rx-Core" version="2.2.5" targetFramework="net452" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
-  <package id="Rx-Linq" version="2.2.5" targetFramework="net452" />
-  <package id="Rx-Main" version="2.2.5" targetFramework="net452" />
-  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" />
-  <package id="Rx-WPF" version="2.2.5" targetFramework="net452" />
-  <package id="Rx-XAML" version="2.2.5" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Fixes #2
Small change to remove dependencies on System.Reactive.* dlls, the correct version of which aren't available on NuGet anymore, and whose absence can cause errors as seen below:
![image](https://user-images.githubusercontent.com/10579271/39077438-949d451c-44b6-11e8-815e-1cc860f4c474.png)
